### PR TITLE
add 'monitor' command to submit_to_nemesis

### DIFF
--- a/cmd/dashboard/dashboard/Nemesis.py
+++ b/cmd/dashboard/dashboard/Nemesis.py
@@ -39,11 +39,11 @@ def build_page(username: str):
     st.subheader("Files")
     cols = st.columns(5)
     with cols[0]:
-        num_plaintext_documents = utils.get_elastic_total_indexed_documents("file_data_plaintext")
-        st.metric("Indexed Documents", num_plaintext_documents)
-    with cols[1]:
         num_enriched_documents = utils.get_elastic_total_indexed_documents("file_data_enriched")
         st.metric("Processed Files", num_enriched_documents)
+    with cols[1]:
+        num_plaintext_documents = utils.get_elastic_total_indexed_documents("file_data_plaintext")
+        st.metric("Indexed Documents", num_plaintext_documents)
     with cols[2]:
         num_np_matches = utils.get_elastic_total_indexed_documents("file_data_enriched", query={"exists": {"field": "noseyparker"}})
         st.metric("NoseyParker Matches", num_np_matches)

--- a/cmd/enrichment/.vscode/launch.json
+++ b/cmd/enrichment/.vscode/launch.json
@@ -55,6 +55,26 @@
                 "--folder",
                 "${workspaceFolder}/../../sample_files"
             ]
+        },
+        {
+            "name": "submit_to_nemesis.py - Monitor",
+            "type": "python",
+            "request": "launch",
+            "module": "enrichment.cli.submit_to_nemesis",
+            "console": "integratedTerminal",
+            "cwd": "${workspaceFolder}",
+            "justMyCode": false,
+            "env": {
+                // "PYTHONASYNCIODEBUG": "1",
+                "BETTER_EXCEPTIONS": "1",
+                "FORCE_COLOR": "1",
+            },
+            "args": [
+                "--monitor",
+                "/tmp/mon",
+                // "-l",
+                // "DEBUG"
+            ]
         }
     ]
 }

--- a/cmd/enrichment/enrichment/cli/submit_to_nemesis/__main__.py
+++ b/cmd/enrichment/enrichment/cli/submit_to_nemesis/__main__.py
@@ -44,7 +44,7 @@ def main():
     loop.set_exception_handler(handle_exception)
 
     try:
-        task = loop.create_task(amain())
+        task = loop.create_task(amain(loop))
         loop.run_until_complete(task)
     finally:
         loop.close()

--- a/cmd/enrichment/enrichment/cli/submit_to_nemesis/file_monitoring.py
+++ b/cmd/enrichment/enrichment/cli/submit_to_nemesis/file_monitoring.py
@@ -1,0 +1,39 @@
+# Standard Libraries
+import asyncio
+import os
+import time
+
+# 3rd Party Libraries
+import structlog
+from watchdog.events import FileSystemEventHandler
+from watchdog.observers import Observer
+
+logger = structlog.getLogger()
+
+
+class NewFileHandler(FileSystemEventHandler):
+    def __init__(self, queue, loop: asyncio.AbstractEventLoop):
+        self.queue = queue
+        self.loop = loop
+
+    def on_created(self, event):
+        if event.is_directory:
+            return
+
+        self.loop.call_soon_threadsafe(self.loop.create_task, self.queue.put(event.src_path))
+
+
+async def monitor_directory(directory, loop):
+    queue = asyncio.Queue()
+    event_handler = NewFileHandler(queue, loop)
+    observer = Observer()
+    observer.schedule(event_handler, directory, recursive=True)
+    observer.start()
+
+    try:
+        while True:
+            file_path = await queue.get()
+            yield file_path
+    finally:
+        observer.stop()
+        observer.join()

--- a/cmd/enrichment/enrichment/tasks/webapi/nemesis_api.py
+++ b/cmd/enrichment/enrichment/tasks/webapi/nemesis_api.py
@@ -92,10 +92,10 @@ async def get_all_rabbit_mq_queues(rabbit_mq_api_url: str) -> List[str]:
             if r.status_code == 200:
                 return [queue["name"] for queue in r.json()]
             else:
-                logger.aerror("Error retrieving RabbitMQ queues from the API", status=r.status_code)
+                await logger.aerror("Error retrieving RabbitMQ queues from the API", status=r.status_code)
                 return []
         except Exception as e:
-            logger.aerror("Error retrieving RabbitMQ queues from the API", exception=e)
+            await logger.aerror("Error retrieving RabbitMQ queues from the API", exception=e)
             return []
 
 
@@ -453,5 +453,5 @@ class NemesisApiRoutes(Routable):
                 #   ref - https://github.com/tiangolo/fastapi/issues/2152#issuecomment-889282903
                 return FileResponse(file.name, background=BackgroundTask(os.remove, file.name), media_type=content_type, headers=headers)
         except Exception as e:
-            logger.aexception(e, message="Failed to download file", file_uuid=id)
+            await logger.aerror(message="Failed to download file", file_uuid=id, exception=e)
             return Response(status_code=404, content="File not found")

--- a/kubernetes/pgadmin/statefulset.yaml
+++ b/kubernetes/pgadmin/statefulset.yaml
@@ -36,6 +36,8 @@ spec:
                   key: pgadmin-password
             - name: SCRIPT_NAME
               value: /pgadmin/
+            - name: MAX_LOGIN_ATTEMPTS
+              value: "10"
           ports:
             - name: http
               containerPort: 80

--- a/sample_files/structured/services_api.json
+++ b/sample_files/structured/services_api.json
@@ -27,7 +27,7 @@
         "agent_id": "339429212",
         "agent_type": "beacon",
         "automated": false,
-        "data_type": "services",
+        "data_type": "service",
         "expiration": "2024-04-03T10:08:40.000Z",
         "source": "DC",
         "project": "ASSESS-X",


### PR DESCRIPTION
- add `--monitor /path/to/dir` command to submit_to_nemesis. This monitors a folder for new files and automatically submits them to Nemesis.
- fixed structured 'service' sample file
- Fixed missing await statements

Demo of monitor mode:
![monitor](https://github.com/SpecterOps/Nemesis/assets/5449193/45ca6e7f-bf7a-4cc8-aa61-6020f8fe7826)
