### PR TITLE
Time conversion bug fix

### DIFF
--- a/cmd/enrichment/enrichment/tasks/webapi/nemesis_api.py
+++ b/cmd/enrichment/enrichment/tasks/webapi/nemesis_api.py
@@ -367,7 +367,7 @@ class NemesisApiRoutes():
 
         try:
             expiration_string = json_data["metadata"]["expiration"]
-            expiration = datetime.strptime(expiration_string, "%Y-%m-%dT%H:%M:%S.000Z")
+            expiration = datetime.strptime(expiration_string, "%Y-%m-%dT%H:%M:%S.%fZ")
         except:
             raise HTTPException(status_code=400, detail=f"Invalid expiration value in metadata field")
 


### PR DESCRIPTION
## Before:
```
>>> from datetime import datetime
>>> valid = "2024-05-15T21:43:07.900Z"
>>> datetime.strptime(valid, "%Y-%m-%dT%H:%M:%S.000Z")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/_strptime.py", line 555, in _strptime_datetime
    tt, fraction, gmtoff_fraction = _strptime(data_string, format)
                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/_strptime.py", line 333, in _strptime
    raise ValueError("time data %r does not match format %r" %
ValueError: time data '2024-05-15T21:43:07.900Z' does not match format '%Y-%m-%dT%H:%M:%S.000Z'
```

## After:
```
>>> from datetime import datetime
>>> valid = "2024-06-14T21:43:07.900Z"
>>> datetime.strptime(valid, "%Y-%m-%dT%H:%M:%S.%fZ")
datetime.datetime(2024, 6, 14, 21, 43, 7, 900000)

>>> valid = "2024-05-15T21:43:07.000Z"
>>> datetime.strptime(valid, "%Y-%m-%dT%H:%M:%S.%fZ")
datetime.datetime(2024, 5, 15, 21, 43, 7)
```


