### PR TITLE
Add missing stylesheet for documentation theme

### DIFF
--- a/docs/stylesheets/colors.css
+++ b/docs/stylesheets/colors.css
@@ -1,0 +1,150 @@
+[data-md-color-scheme="nemesis-dark"] {
+  color-scheme: dark;
+
+  --md-primary-fg-color: #262730;
+
+  --mod-hue: 210;
+
+  --md-default-fg-color:             hsla(var(--md-hue), 15%, 90%, 0.82);
+  --md-default-fg-color--light:      hsla(var(--md-hue), 15%, 90%, 0.56);
+  --md-default-fg-color--lighter:    hsla(var(--md-hue), 15%, 90%, 0.32);
+  --md-default-fg-color--lightest:   hsla(var(--md-hue), 15%, 90%, 0.12);
+  --md-default-bg-color:             #0E1116;
+  --md-default-bg-color--light:      hsla(var(--md-hue), 15%, 14%, 0.54);
+  --md-default-bg-color--lighter:    hsla(var(--md-hue), 15%, 14%, 0.26);
+  --md-default-bg-color--lightest:   hsla(var(--md-hue), 15%, 14%, 0.07);
+
+  --md-code-fg-color:                hsla(var(--md-hue), 18%, 86%, 0.82);
+  --md-code-bg-color:                hsla(var(--md-hue), 15%, 18%, 1);
+
+  --md-code-hl-number-color: #619a8c;
+  --md-code-hl-special-color: var(--md-code-hl-number-color);
+  --md-code-hl-function-color: #5382db;
+  --md-code-hl-string-color: #61a242;
+  --md-code-hl-operator-color: #965822;
+  --md-code-hl-name-color:           #e4e4e4;
+  --md-code-hl-keyword-color:        #4b74c6;
+  --md-code-hl-punctuation-color:    #808080;
+  --md-code-hl-constant-color:       hsla(250, 62%, 70%, 1);
+  --md-code-hl-comment-color:        rgb(98, 103, 119);
+  --md-code-hl-variable-color:       #ffffff;
+  --md-code-hl-color:                hsla(#{hex2hsl($clr-blue-a400)}, 1);
+  --md-code-hl-color--light:         hsla(#{hex2hsl($clr-blue-a400)}, 0.1);
+  --md-code-hl-generic-color:        var(--md-default-fg-color--light);
+
+  --md-typeset-color:                var(--md-default-fg-color);
+  --md-typeset-a-color:              #498AFB;
+
+  --md-typeset-kbd-color:            hsla(var(--md-hue), 15%, 90%, 0.12);
+  --md-typeset-kbd-accent-color:     hsla(var(--md-hue), 15%, 90%, 0.2);
+  --md-typeset-kbd-border-color:     hsla(var(--md-hue), 15%, 14%, 1);
+
+  --md-typeset-mark-color:           hsla(#{hex2hsl($clr-blue-a200)}, 0.3);
+
+  --md-typeset-table-color:          hsla(var(--md-hue), 15%, 95%, 0.12);
+  --md-typeset-table-color--light:   hsla(var(--md-hue), 15%, 95%, 0.035);
+
+  --md-admonition-fg-color:          var(--md-default-fg-color);
+  --md-admonition-bg-color:          var(--md-default-bg-color);
+
+  --md-footer-bg-color:              hsla(var(--md-hue), 15%, 10%, 0.87);
+  --md-footer-bg-color--dark:        hsla(var(--md-hue), 15%, 8%, 1);
+
+  --md-shadow-z1:
+    0 #{px2rem(4px)} #{px2rem(10px)} hsla(0, 0%, 0%, 0.05),
+    0 0              #{px2rem(1px)}  hsla(0, 0%, 0%, 0.1);
+
+  --md-shadow-z2:
+    0 #{px2rem(4px)} #{px2rem(10px)} hsla(0, 0%, 0%, 0.25),
+    0 0              #{px2rem(1px)}  hsla(0, 0%, 0%, 0.25);
+
+  --md-shadow-z3:
+    0 #{px2rem(4px)} #{px2rem(10px)} hsla(0, 0%, 0%, 0.4),
+    0 0              #{px2rem(1px)}  hsla(0, 0%, 0%, 0.35);
+
+  img[src$="#only-light"],
+  img[src$="#gh-light-mode-only"] {
+    display: none;
+  }
+}
+
+[data-md-color-scheme="nemesis-light"] {
+  color-scheme: light;
+
+  --md-primary-fg-color: #262730;
+
+  --md-hue: 225deg;
+
+  --md-default-fg-color:               hsla(0, 0%, 0%, 0.87);
+  --md-default-fg-color--light:        hsla(0, 0%, 0%, 0.54);
+  --md-default-fg-color--lighter:      hsla(0, 0%, 0%, 0.32);
+  --md-default-fg-color--lightest:     hsla(0, 0%, 0%, 0.07);
+  --md-default-bg-color:               hsla(0, 0%, 100%, 1);
+  --md-default-bg-color--light:        hsla(0, 0%, 100%, 0.7);
+  --md-default-bg-color--lighter:      hsla(0, 0%, 100%, 0.3);
+  --md-default-bg-color--lightest:     hsla(0, 0%, 100%, 0.12);
+
+  --md-code-fg-color:                  hsla(200, 18%, 26%, 1);
+  --md-code-bg-color:                  hsla(200, 0%, 96%, 1);
+
+  --md-code-hl-color:                  hsla(#{hex2hsl($clr-blue-a200)}, 1);
+  --md-code-hl-color--light:           hsla(#{hex2hsl($clr-blue-a200)}, 0.1);
+
+  --md-code-hl-number-color:           hsla(0, 67%, 50%, 1);
+  --md-code-hl-special-color:          hsla(340, 83%, 47%, 1);
+  --md-code-hl-function-color:         hsla(291, 45%, 50%, 1);
+  --md-code-hl-constant-color:         hsla(250, 63%, 60%, 1);
+  --md-code-hl-keyword-color:          hsla(219, 54%, 51%, 1);
+  --md-code-hl-string-color:           hsla(150, 63%, 30%, 1);
+  --md-code-hl-name-color:             var(--md-code-fg-color);
+  --md-code-hl-operator-color:         var(--md-default-fg-color--light);
+  --md-code-hl-punctuation-color:      var(--md-default-fg-color--light);
+  --md-code-hl-comment-color:          var(--md-default-fg-color--light);
+  --md-code-hl-generic-color:          var(--md-default-fg-color--light);
+  --md-code-hl-variable-color:         var(--md-default-fg-color--light);
+
+  --md-typeset-color:                  var(--md-default-fg-color);
+
+  --md-typeset-a-color:              #498AFB;
+
+  --md-typeset-del-color:              hsla(6, 90%, 60%, 0.15);
+  --md-typeset-ins-color:              hsla(150, 90%, 44%, 0.15);
+
+  --md-typeset-kbd-color:              hsla(0, 0%, 98%, 1);
+  --md-typeset-kbd-accent-color:       hsla(0, 100%, 100%, 1);
+  --md-typeset-kbd-border-color:       hsla(0, 0%, 72%, 1);
+
+  --md-typeset-mark-color:             hsla(#{hex2hsl($clr-yellow-a200)}, 0.5);
+
+  --md-typeset-table-color:            hsla(0, 0%, 0%, 0.12);
+  --md-typeset-table-color--light:     hsla(0, 0%, 0%, 0.035);
+
+  --md-admonition-fg-color:            var(--md-default-fg-color);
+  --md-admonition-bg-color:            var(--md-default-bg-color);
+
+  --md-warning-fg-color:              hsla(0, 0%, 0%, 0.87);
+  --md-warning-bg-color:              hsla(60, 100%, 80%, 1);
+
+  --md-footer-fg-color:                hsla(0, 0%, 100%, 1);
+  --md-footer-fg-color--light:         hsla(0, 0%, 100%, 0.7);
+  --md-footer-fg-color--lighter:       hsla(0, 0%, 100%, 0.45);
+  --md-footer-bg-color:                hsla(0, 0%, 0%, 0.87);
+  --md-footer-bg-color--dark:          hsla(0, 0%, 0%, 0.32);
+
+  --md-shadow-z1:
+    0 #{px2rem(4px)} #{px2rem(10px)} hsla(0, 0%, 0%, 0.05),
+    0 0              #{px2rem(1px)}  hsla(0, 0%, 0%, 0.1);
+
+  --md-shadow-z2:
+    0 #{px2rem(4px)} #{px2rem(10px)} hsla(0, 0%, 0%, 0.1),
+    0 0              #{px2rem(1px)}  hsla(0, 0%, 0%, 0.25);
+
+  --md-shadow-z3:
+    0 #{px2rem(4px)} #{px2rem(10px)} hsla(0, 0%, 0%, 0.2),
+    0 0              #{px2rem(1px)}  hsla(0, 0%, 0%, 0.35);
+
+  img[src$="#only-dark"],
+  img[src$="#gh-light-mode-only"] {
+    display: none;
+  }
+}


### PR DESCRIPTION
It seems that during the rewrite, the stylesheet for the Nemesis documentation page was removed [`SpecterOps/Nemesis/commit/889613f`](https://github.com/SpecterOps/Nemesis/commit/889613f44cc2768c8c2f1f5486601437c20080b1#diff-72ff9846b7f7ef1d47692767135115d90ef90ef733cb33f9499ca162b2708d2f).

I do not know if this was intentional or accidental but the [`mkdocs.yml#L49`](https://github.com/SpecterOps/Nemesis/blob/18af5774b6d6efef10e7ad58de8d53891e8c8ba5/mkdocs.yml#L49) still references the `nemesis-light` and `nemesis-dark` color schemes from the missing stylesheet.

This should also fix the dark mode toggle button at the top of the page for people who prefer dark mode.