### PR TITLE
[codex] CI fast gate and nightly Docker validation

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -2,6 +2,41 @@
 
 This directory contains GitHub Action workflows for automating tasks related to the Nemesis project.
 
+## CI Fast Gate Workflow
+
+The `ci-fast.yml` workflow is the required pull request quality gate for Python projects.
+
+### Workflow Trigger
+
+The workflow runs on:
+- Pull requests targeting `main` (excluding docs-only changes)
+- Manual triggers via the GitHub Actions UI (`workflow_dispatch`)
+
+### What It Does
+
+1. Installs `uv` and Python 3.13.
+2. Restores `uv` cache keyed by all `uv.lock` files.
+3. Runs dependency synchronization (`./tools/install_dev_env.sh`).
+4. Runs tests (`./tools/test.sh`).
+5. Runs non-mutating type checks (`./tools/typecheck.sh`).
+
+## Nightly Docker Validation Workflow
+
+The `docker-validate-nightly.yml` workflow validates that Nemesis images build successfully without publishing images.
+
+### Workflow Trigger
+
+The workflow runs on:
+- Daily schedule at `10:00 UTC`
+- Manual triggers via the GitHub Actions UI (`workflow_dispatch`)
+
+### What It Does
+
+1. Builds base images from `compose.base.yaml`.
+2. Builds production service images from `compose.yaml` + `compose.prod.build.yaml`.
+3. Builds the CLI production image explicitly.
+4. Executes on both `amd64` and `arm64` GitHub runners.
+
 ## Docker Build and Publish Workflow
 
 The `docker-build.yml` workflow automatically builds and publishes Docker images for all Nemesis services to the GitHub Container Registry (ghcr.io).
@@ -9,9 +44,8 @@ The `docker-build.yml` workflow automatically builds and publishes Docker images
 ### Workflow Trigger
 
 The workflow runs on:
-- Push to the `main` branch (when specific paths are modified)
-- Pull requests targeting the `main` branch (when specific paths are modified)
-- Manual triggers via the GitHub Actions UI (workflow_dispatch)
+- Pushes of release tags matching `v*.*.*`
+- Manual triggers via the GitHub Actions UI (`workflow_dispatch`)
 
 ### What It Does
 

--- a/.github/workflows/ci-fast.yml
+++ b/.github/workflows/ci-fast.yml
@@ -1,0 +1,48 @@
+name: CI Fast Gate
+
+on:
+  pull_request:
+    branches: [ "main" ]
+    paths-ignore:
+      - "docs/**"
+      - "mkdocs.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: ci-fast-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  python-test-and-typecheck:
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.13
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Cache uv artifacts
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/uv
+          key: ${{ runner.os }}-uv-${{ hashFiles('**/uv.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-uv-
+
+      - name: Install project dependencies
+        run: ./tools/install_dev_env.sh
+
+      - name: Run unit tests
+        run: ./tools/test.sh
+
+      - name: Run pyright type checks
+        run: ./tools/typecheck.sh

--- a/.github/workflows/docker-validate-nightly.yml
+++ b/.github/workflows/docker-validate-nightly.yml
@@ -1,0 +1,40 @@
+name: Docker Validate Nightly
+
+on:
+  schedule:
+    - cron: "0 10 * * *"
+  workflow_dispatch:
+
+jobs:
+  build-images:
+    name: Build validate (${{ matrix.arch }})
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-22.04
+            arch: amd64
+          - runner: ubuntu-22.04-arm
+            arch: arm64
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Prepare compose environment file
+        run: cp env.example .env
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build base images
+        run: docker compose -f compose.base.yaml build
+
+      - name: Build production service images
+        run: docker compose -f compose.yaml -f compose.prod.build.yaml build
+
+      - name: Build CLI production image
+        run: docker build -f ./projects/cli/Dockerfile --target prod .

--- a/tools/typecheck.sh
+++ b/tools/typecheck.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Get the absolute path to the project root (one level up from the tools folder)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BASE_DIR="$(dirname "$SCRIPT_DIR")"
+
+TARGET_DIRS=("$BASE_DIR/projects" "$BASE_DIR/libs")
+
+if ! command -v uv >/dev/null 2>&1; then
+    echo "Error: 'uv' not found."
+    echo "Install uv first: curl -LsSf https://astral.sh/uv/install.sh | sh"
+    exit 1
+fi
+
+PYRIGHT_CONFIGS=()
+while IFS= read -r config; do
+    PYRIGHT_CONFIGS+=("$config")
+done < <(find "${TARGET_DIRS[@]}" -maxdepth 2 -name "pyrightconfig.json" -type f | sort)
+
+if [ "${#PYRIGHT_CONFIGS[@]}" -eq 0 ]; then
+    echo "No pyrightconfig.json files found under projects/ or libs/."
+    exit 0
+fi
+
+RUNNING_IN_CI="${GITHUB_ACTIONS:-false}"
+OS_NAME="$(uname -s)"
+
+echo "Running pyright checks across ${#PYRIGHT_CONFIGS[@]} projects..."
+FAILED=0
+
+for config in "${PYRIGHT_CONFIGS[@]}"; do
+    PROJECT_DIR="$(dirname "$config")"
+    PROJECT_NAME="$(basename "$PROJECT_DIR")"
+
+    # Local macOS runs often lack LevelDB headers needed by the CLI project's
+    # transitive build dependency. Keep CI authoritative by only skipping this
+    # project for local (non-CI) runs.
+    if [ "$RUNNING_IN_CI" != "true" ] && [ "$OS_NAME" = "Darwin" ] && [ "$PROJECT_NAME" = "cli" ]; then
+        echo ""
+        echo "=== Skipping local type check: $PROJECT_NAME ($PROJECT_DIR) ==="
+        echo "Reason: local macOS prerequisite mismatch; this project is still checked in CI."
+        continue
+    fi
+
+    echo ""
+    echo "=== Type checking: $PROJECT_NAME ($PROJECT_DIR) ==="
+    if (cd "$PROJECT_DIR" && uv run pyright); then
+        echo "PASS: $PROJECT_NAME"
+    else
+        echo "FAIL: $PROJECT_NAME"
+        FAILED=1
+    fi
+done
+
+echo ""
+if [ "$FAILED" -ne 0 ]; then
+    echo "Pyright checks failed."
+    exit 1
+fi
+
+echo "All pyright checks passed."


### PR DESCRIPTION
## Summary
This PR implements a CI-first build validation approach for Nemesis and keeps image publishing workflows separate.

## What changed
- Added a non-mutating typecheck runner: `tools/typecheck.sh`
  - Discovers all project/library `pyrightconfig.json` files.
  - Runs `uv run pyright` per project and aggregates failures.
  - Skips `projects/cli` only for local macOS non-CI runs to avoid local LevelDB header prerequisite issues while preserving CI authority.
- Added a fast PR quality gate workflow: `.github/workflows/ci-fast.yml`
  - Triggers on `pull_request` to `main` and `workflow_dispatch`.
  - Uses Python 3.13 + uv cache.
  - Runs dependency sync, tests, and type checks.
- Added nightly Docker build validation workflow: `.github/workflows/docker-validate-nightly.yml`
  - Triggers at `10:00 UTC` daily and via `workflow_dispatch`.
  - Runs on both `amd64` and `arm64` runners.
  - Build-only validation (no registry login, no push, no manifests).
  - Builds base images, production compose images, and CLI prod image.
- Updated workflow docs: `.github/workflows/README.md`
  - Documented new `ci-fast` and nightly validation workflows.
  - Corrected `docker-build.yml` trigger description to match release tags/manual dispatch.

## Why
- Make GitHub Actions the authoritative build health signal.
- Keep PR checks fast and actionable.
- Catch Docker regressions nightly across both target architectures without publishing artifacts.

## Validation
- `bash -n tools/typecheck.sh`
- Local run: `./tools/typecheck.sh` (passes locally with explicit local-macOS `cli` skip)
- YAML/TOML parse checks for new workflow/config files.

## Notes
- Existing publish workflows are intentionally unchanged:
  - `.github/workflows/docker-build.yml`
  - `.github/workflows/docker-build-base.yml`
  - `.github/workflows/docker-build-noseyparker.yml`
