### PR TITLE
fix: properly accumulate env vars in nemesis-ctl.sh

### DIFF
--- a/tools/nemesis-ctl.sh
+++ b/tools/nemesis-ctl.sh
@@ -114,11 +114,11 @@ fi
 
 # --- Build Command ---
 declare -a DOCKER_CMD=("docker" "compose")
-declare -a CMD_PREFIX=()
+declare -a ENV_VARS=()
 
 # 1. Handle Profiles and associated Environment Variables
 if [ "$MONITORING" = "true" ]; then
-  CMD_PREFIX=( "env" "NEMESIS_MONITORING=enabled" )
+  ENV_VARS+=("NEMESIS_MONITORING=enabled")
   DOCKER_CMD+=("--profile" "monitoring")
 fi
 
@@ -132,7 +132,7 @@ if [ "$LLM" = "true" ]; then
     echo "Error: PHOENIX_ENABLED must be 'true' or 'false', got '$PHOENIX_ENABLED'." >&2
     exit 1
   fi
-  CMD_PREFIX+=("PHOENIX_ENABLED=${PHOENIX_ENABLED:-true}")
+  ENV_VARS+=("PHOENIX_ENABLED=${PHOENIX_ENABLED:-true}")
 fi
 
 # 2. Handle Environment-specific files
@@ -182,11 +182,11 @@ fi
 echo
 echo "Running command:"
 
-# Determine the final command outside the subshell
-if [ ${#CMD_PREFIX[@]} -eq 0 ]; then
-  FINAL_CMD=("${DOCKER_CMD[@]}")
+# Build final command with environment variables if needed
+if [ ${#ENV_VARS[@]} -gt 0 ]; then
+  FINAL_CMD=("env" "${ENV_VARS[@]}" "${DOCKER_CMD[@]}")
 else
-  FINAL_CMD=("${CMD_PREFIX[@]}" "${DOCKER_CMD[@]}")
+  FINAL_CMD=("${DOCKER_CMD[@]}")
 fi
 
 (


### PR DESCRIPTION
## Summary

Fix an issue in `tools/nemesis-ctl.sh` where environment variables were incorrectly accumulated into the command prefix array.

When the `--llm` option was used without `--monitoring`, the script produced a command like:

```
PHOENIX_ENABLED=true docker compose ...
```

However, because the command is executed via array expansion rather than shell parsing, `PHOENIX_ENABLED=true` was interpreted as a command instead of an environment variable assignment, resulting in:

```
PHOENIX_ENABLED=true: command not found
```

## Root Cause

The script previously stored both the command prefix (`env`) and environment variable assignments in the same array (`CMD_PREFIX`). This caused incorrect command construction when no `env` prefix was present.

## Fix

This PR separates environment variable accumulation from command construction:

- Introduces a dedicated `ENV_VARS` array to collect environment variable assignments.
- Builds the final command using:

```
env "${ENV_VARS[@]}" docker compose ...
```

when environment variables are present.

## Result

Commands such as:

```
./tools/nemesis-ctl.sh start prod --llm
```

now correctly execute as:

```
env PHOENIX_ENABLED=true docker compose ...
```

without requiring other profiles (e.g. `--monitoring`) to be enabled.

## Notes

This change preserves existing behavior for other profiles while ensuring consistent handling of environment variables across all combinations of options.