### PR TITLE
Remove dependencies on public CDNs

### DIFF
--- a/projects/frontend/Dockerfile
+++ b/projects/frontend/Dockerfile
@@ -39,6 +39,7 @@ FROM nginx:alpine AS prod
 RUN apk add --no-cache wget
 
 COPY --from=bundle /app/dist /usr/share/nginx/html
+COPY --from=bundle /app/node_modules/sql.js/dist/ /usr/share/nginx/html/assets/sql.js
 COPY nginx.conf /etc/nginx/conf.d/default.conf
 
 # Create env.js with placeholder for runtime substitution

--- a/projects/frontend/package-lock.json
+++ b/projects/frontend/package-lock.json
@@ -17,6 +17,7 @@
         "graphql-ws": "^6.0.0",
         "jszip": "^3.10.1",
         "lucide-react": "^0.263.1",
+        "monaco-editor": "^0.55.1",
         "papaparse": "^5.5.2",
         "patch-package": "^8.0.1",
         "react": "^18.2.0",
@@ -2056,8 +2057,7 @@
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
       "license": "MIT",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/@types/unist": {
       "version": "3.0.3",
@@ -2787,7 +2787,6 @@
       "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.2.tgz",
       "integrity": "sha512-lHeS9SA/IKeIFFyYciHBr2n0v1VMPlSj843HdLOwjb2OxNwdq9Xykxqhk+FE42MzAdHvInbAolSE4mhahPpjXA==",
       "license": "(MPL-2.0 OR Apache-2.0)",
-      "peer": true,
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
       }
@@ -3709,7 +3708,6 @@
       "resolved": "https://registry.npmjs.org/marked/-/marked-14.0.0.tgz",
       "integrity": "sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -4601,7 +4599,6 @@
       "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.55.1.tgz",
       "integrity": "sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "dompurify": "3.2.7",
         "marked": "14.0.0"

--- a/projects/frontend/package.json
+++ b/projects/frontend/package.json
@@ -18,6 +18,7 @@
     "graphql-ws": "^6.0.0",
     "jszip": "^3.10.1",
     "lucide-react": "^0.263.1",
+    "monaco-editor": "^0.55.1",
     "papaparse": "^5.5.2",
     "patch-package": "^8.0.1",
     "react": "^18.2.0",

--- a/projects/frontend/src/components/FileViewer/SQLiteViewer.jsx
+++ b/projects/frontend/src/components/FileViewer/SQLiteViewer.jsx
@@ -39,9 +39,9 @@ const SQLiteViewer = ({ fileBuffer, fileName }) => {
     useEffect(() => {
         const loadSqlJs = async () => {
             try {
-                // Use CDN directly for sql.js WASM file
+                // Get sql.js WASM file from assets
                 const SQL = await initSQLJS({
-                    locateFile: file => `https://cdnjs.cloudflare.com/ajax/libs/sql.js/1.13.0/${file}`,
+                    locateFile: file => `/assets/sql.js/${file}`,
                 });
 
                 console.log('Successfully loaded SQL.js WASM from CDN');

--- a/projects/frontend/src/index.jsx
+++ b/projects/frontend/src/index.jsx
@@ -1,7 +1,11 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+import loader from '@monaco-editor/loader';
+import * as monaco from 'monaco-editor';
 import App from './App';
 import './index.css';
+
+loader.config({ monaco });
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>


### PR DESCRIPTION
I'm using Nemesis in environments without internet connection, and some components depend on public CDNs that will not resolve in those environments.

This PR replaces the CDN usage for Monaco and SQL.js. I haven't checked if these are _all_ public CDN dependencies.